### PR TITLE
Fix for NCDFE in test when using CloseableBundleContext

### DIFF
--- a/impl/src/integration-test/kotlin/com/example/osgi/test/DeploymentTest.kt
+++ b/impl/src/integration-test/kotlin/com/example/osgi/test/DeploymentTest.kt
@@ -1,14 +1,18 @@
 package com.example.osgi.test
 
+import kotlin.reflect.KClass;
 import com.example.osgi.api.Greetings
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.osgi.framework.ServiceListener
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
 
 @ExtendWith(ServiceExtension::class)
 class DeploymentTest {
+
+    var listener: KClass<ServiceListener> = ServiceListener::class
 
     @InjectService(timeout = 1000)
     lateinit var greetings: Greetings


### PR DESCRIPTION
Hi Chris,

Here is a workaround for your problem. Fixes the NCDFE under Java 1.8 by forcing Bnd to generate an `Import-Package` declaration for `org.osgi.framework` in your tests bundle.

I think this is an osgi-test bug. I'll raise an issue on osgi-test and we'll follow up.

Blessings!